### PR TITLE
Restaurar verificación de estado de servidores AFIP

### DIFF
--- a/app/factura_electronica.py
+++ b/app/factura_electronica.py
@@ -91,14 +91,6 @@ def facturar(json_data: Dict[str, Any], production: bool = False) -> Dict[str, A
             logger.error(f"Error en autenticación: {str(auth_error)}")
             raise
 
-        # Verificar estado de conexión
-        try:
-            wsfev1.Dummy()
-            logger.info(f"Estado de servidores - AppServer: {wsfev1.AppServerStatus}, DbServer: {wsfev1.DbServerStatus}, AuthServer: {wsfev1.AuthServerStatus}")
-        except Exception as dummy_error:
-            logger.error(f"Error en verificación de conexión: {str(dummy_error)}")
-            raise
-
         wsfev1.Cuit = CUIT
         wsfev1.SetTicketAcceso(ta)
         wsfev1.Conectar(CACHE, URL_WSFEv1)


### PR DESCRIPTION
## 🔄 Restaurar verificación de estado de servidores AFIP

### Descripción
Se ha removido el bloque de código que verifica el estado de los servidores de AFIP (Dummy check) antes de proceder con la facturación. Esta verificación es importante para asegurar la disponibilidad del servicio.
